### PR TITLE
Add back in the concept of an originating user

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -26,6 +26,7 @@ class NotificationsController < ApplicationController
   def show
     render json: Notification.for_notification_stream(params[:user_id],
                                                       params[:category],
+                                                      excluded_originating_user_ids,
                                                       params[:before],
                                                       params[:limit]
                                                      ).to_json
@@ -33,12 +34,17 @@ class NotificationsController < ApplicationController
 
   private
 
+  def excluded_originating_user_ids
+    (params[:exclude_originating_user_ids] || '').split(',').map(&:to_i)
+  end
+
   def notification_params
     params.permit(:user_id,
                   :subject_id,
                   :subject_type,
                   :kind,
-                  :created_at)
+                  :created_at,
+                  :originating_user_id)
   end
 
 end

--- a/app/interactors/destroy_notifications_for_user.rb
+++ b/app/interactors/destroy_notifications_for_user.rb
@@ -2,7 +2,8 @@ class DestroyNotificationsForUser
   include Interactor
 
   def call
-    scope = Notification.where(user_id: context.user_id)
-    context.fail! unless scope.delete_all
+    user_scope = Notification.where(user_id: context.user_id)
+    originating_scope = Notification.where(originating_user_id: context.user_id)
+    context.fail! unless user_scope.delete_all && originating_scope.delete_all
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -82,7 +82,11 @@ class Notification < ApplicationRecord
     where(user_id: user_id)
   end
 
-  def self.for_notification_stream(user_id, category = nil, before = nil, limit = nil)
+  def self.for_notification_stream(user_id,
+                                   category = nil,
+                                   excluded_originating_user_ids = [],
+                                   before = nil,
+                                   limit = nil)
     category ||= :all
     limit ||= 25
     before = Time.parse(before) if before.is_a?(String)
@@ -91,6 +95,7 @@ class Notification < ApplicationRecord
     for_user(user_id).
       select(*SELECTED_FIELDS).
       where(kind: NOTIFICATION_CATEGORIES[category.to_sym]).
+      where.not(originating_user_id: excluded_originating_user_ids).
       where('created_at < ?', before).
       order('created_at DESC').
       limit(limit)

--- a/db/migrate/20160218171419_add_originating_user_id_to_notifications.rb
+++ b/db/migrate/20160218171419_add_originating_user_id_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddOriginatingUserIdToNotifications < ActiveRecord::Migration[5.0]
+  def change
+    add_column :notifications, :originating_user_id, :integer, index: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160216220624) do
+ActiveRecord::Schema.define(version: 20160218171419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "notifications", id: false, force: :cascade do |t|
-    t.integer  "user_id",      null: false
-    t.integer  "subject_id",   null: false
-    t.string   "subject_type", null: false
-    t.datetime "created_at",   null: false
-    t.string   "kind",         null: false
+    t.integer  "user_id",             null: false
+    t.integer  "subject_id",          null: false
+    t.string   "subject_type",        null: false
+    t.datetime "created_at",          null: false
+    t.string   "kind",                null: false
+    t.integer  "originating_user_id", null: false
     t.index ["subject_id", "subject_type"], name: "index_notifications_on_subject_id_and_subject_type", using: :btree
     t.index ["user_id", "created_at", "subject_id", "subject_type", "kind"], name: "covering_index_on_notifications", unique: true, using: :btree
   end


### PR DESCRIPTION
- Make it a required field for the create endpoint
- Add a secondary index on originating_user_id for deletion
- Allow filtering of originating users via `exclude_originating_user_ids` in the show endpoint (comma-separated list of IDs)
- Remove notifications originating from a user when destroying based on user id

/cc @alanpeabody

[#114014727,#114014801,#114014167]